### PR TITLE
add support for git submodules when updating website

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@
 
 ### Website
 
+Fully deploy the website:
 `cd ansible && ansible-playbook --vault-id @prompt deploy-website.yml`
+
+Update the website:
+`cd ansible && ansible-playbook --vault-id @prompt deploy-website.yml --tags "update"`
 
 
 ## Naming convention

--- a/ansible/roles/caddy-website/tasks/build-website.yml
+++ b/ansible/roles/caddy-website/tasks/build-website.yml
@@ -75,12 +75,12 @@
 #    owner: caddy
 #    group: caddy
 #  notify: "restart caddy"
-
-- name: clone website from repo
-  git:
-    repo: "{{ hugo_website_git_repo }}"
-    dest: "{{ hugo_src_website }}"
-  become_user: caddy
+#
+#- name: clone website from repo
+#  git:
+#    repo: "{{ hugo_website_git_repo }}"
+#    dest: "{{ hugo_src_website }}"
+#  become_user: caddy
 
 - name: deploy script to update the website from latest git
   template:
@@ -89,11 +89,14 @@
     owner: caddy
     group: caddy
     mode: '0700' # make executable
+  tags: update
+
 
 - name: update website
   shell: "{{ update_website_script_path }}"
   become: yes
   become_user: caddy
+  tags: update
 
 - name: remove the temporary build folder
   file:

--- a/ansible/roles/caddy-website/templates/update-website.sh.j2
+++ b/ansible/roles/caddy-website/templates/update-website.sh.j2
@@ -14,8 +14,9 @@ output_dir=$tmp_build
 set -e
 
 # update website
-cd $input_dir
+cd $input_dir || git clone --recursive {{ hugo_website_git_repo }} {{ hugo_src_website }} && cd $input_dir
 git pull
+git submodule update --recursive --remote # update submodules
 
 # remove the previous docker images
 docker rm -f hugo


### PR DESCRIPTION
Sometimes we need to add submodules to the website (presentations,
for example). This adds that suppor and also makes it easier to
deploy the website with the use of ansible playbook tags:

```bash
cd ansible && ansible-playbook --vault-id @prompt deploy-website.yml --tags "update"
```