### PR TITLE
bump discourse to v 2.3.6 (fixes CVE-2019-15515)

### DIFF
--- a/ansible/roles/discourse/defaults/main.yml
+++ b/ansible/roles/discourse/defaults/main.yml
@@ -7,4 +7,4 @@ dis_guest_path: /shared
 dis_path: /var/discourse
 dis_git: https://github.com/discourse/discourse_docker.git
 # Use a stable release - https://github.com/discourse/discourse/releases
-dis_version: v2.3.2
+dis_version: v2.3.6


### PR DESCRIPTION
This has already been deployed to the production machine