### PR TITLE
Enable Discourse checks, set testing to test-passed branch

### DIFF
--- a/ansible/inventory/testing/group_vars/discourse/vars.yml
+++ b/ansible/inventory/testing/group_vars/discourse/vars.yml
@@ -15,3 +15,4 @@ dis_smtp_pass: !vault |
 dis_le_email: cafe-testing@privacylx.org
 dis_developer_emails:
   - cafe-testing@privacylx.org
+dis_version: tests-passed

--- a/ansible/roles/discourse/handlers/main.yml
+++ b/ansible/roles/discourse/handlers/main.yml
@@ -1,4 +1,0 @@
----
-
-- name: launcher rebuild
-  command: "{{ dis_path }}/launcher rebuild app"

--- a/ansible/roles/discourse/tasks/main.yml
+++ b/ansible/roles/discourse/tasks/main.yml
@@ -19,20 +19,20 @@
 - name: Get Discourse container info
   docker_container_info:
     name: app
-  register: dis_ct
+  register: discourse_container
 
 - name: Print the status of the Discourse container
   debug:
-    msg: "The container status is {{ dis_ct.container.State.Status }}"
-  when: dis_ct.exists
+    msg: "The container status is {{ discourse_container.container.State.Status }}"
+  when: discourse_container.exists
 
 - name: (Re)build Discourse container configuration
   command: "{{ dis_path }}/launcher rebuild app"
-  when: not dis_ct.exists or dis_template.changed
+  when: not discourse_container.exists or dis_template.changed
 
-- name: Start Discourse container if it's not running
+- name: Start Discourse container if it's already exist but not running
   command: "{{ dis_path }}/launcher start app"
   when:
     - not dis_template.changed
-    - dis_ct.exists
-    - dis_ct.container.State.Status != 'running'
+    - discourse_container.exists
+    - discourse_container.container.State.Status != 'running'

--- a/ansible/roles/discourse/tasks/main.yml
+++ b/ansible/roles/discourse/tasks/main.yml
@@ -5,7 +5,7 @@
     path: "{{ dis_path }}"
     state: directory
 
-- name: Clones Discource git repository
+- name: Clones Discourse git repository
   git:
     repo: "{{ dis_git }}"
     dest: "{{ dis_path }}"
@@ -14,5 +14,25 @@
   template:
     src: standalone.yml.j2
     dest: "{{ dis_path }}/containers/app.yml"
-  notify:
-    launcher rebuild
+  register: dis_template
+
+- name: Get Discourse container info
+  docker_container_info:
+    name: app
+  register: dis_ct
+
+- name: Print the status of the Discourse container
+  debug:
+    msg: "The container status is {{ dis_ct.container.State.Status }}"
+  when: dis_ct.exists
+
+- name: (Re)build Discourse container configuration
+  command: "{{ dis_path }}/launcher rebuild app"
+  when: not dis_ct.exists or dis_template.changed
+
+- name: Start Discourse container if it's not running
+  command: "{{ dis_path }}/launcher start app"
+  when:
+    - not dis_template.changed
+    - dis_ct.exists
+    - dis_ct.container.State.Status != 'running'

--- a/ansible/roles/discourse/templates/standalone.yml.j2
+++ b/ansible/roles/discourse/templates/standalone.yml.j2
@@ -52,7 +52,7 @@ env:
 
   ## Uncomment if you want the container to be started with the same
   ## hostname (-h option) as specified above (default "$hostname-$config")
-  DOCKER_USE_HOSTNAME: true
+  DOCKER_USE_HOSTNAME: false
 
   ## TODO: List of comma delimited emails that will be made admin and developer
   ## on initial signup example 'user1@example.com,user2@example.com'
@@ -65,7 +65,7 @@ env:
   DISCOURSE_SMTP_PORT: {{ dis_smtp_port }}
   DISCOURSE_SMTP_USER_NAME: {{ dis_smtp_user }}
   DISCOURSE_SMTP_PASSWORD: {{ dis_smtp_pass }}
-  #DISCOURSE_SMTP_ENABLE_START_TLS: true           # (optional, default true)
+  DISCOURSE_SMTP_ENABLE_START_TLS: true
 
   ## If you added the Lets Encrypt template, uncomment below to get a free SSL certificate
   LETSENCRYPT_ACCOUNT_EMAIL: {{ dis_le_email }}
@@ -97,5 +97,5 @@ run:
   - exec: echo "Beginning of custom commands"
   ## If you want to set the 'From' email address for your first registration, uncomment and change:
   ## After getting the first signup email, re-comment the line. It only needs to run once.
-  - exec: rails r "SiteSetting.notification_email='{{ dis_smtp_user }}'"
+  #- exec: rails r "SiteSetting.notification_email='{{ dis_smtp_user }}'"
   - exec: echo "End of custom commands"


### PR DESCRIPTION
* Checks if Discourse container is running and starts/rebuild the
  container accordingly.
* Testing changed to use the test-passed branch
* Config: no need for same hostname in Docker not, disable
  SiteSetting.notification_email config used for the first signup