### PR TITLE
Fix: no set update tag to all tasks, README, check mode, syslog

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,12 +105,12 @@ and reboots the host if it's required (set `reboot_enabled` to `true`).
 
 #### Deploying updates
 
-`cd ansible && ansible-playbook -i inventory/production deploy-update.yml`
+`cd ansible && ansible-playbook -i inventory/production deploy-update.yml --tags update`
 
 Running the role with `reboot_enabled` will reboot a host that requires reboot
 after package upgrades:
 
-`cd ansible && ansible-playbook -i inventory/production deploy-update.yml --extra-vars=reboot_enabled=true`
+`cd ansible && ansible-playbook -i inventory/production deploy-update.yml --tags update --extra-vars=reboot_enabled=true`
 
 ### Deploy BigBlueButton
 

--- a/README.md
+++ b/README.md
@@ -105,12 +105,12 @@ and reboots the host if it's required (set `reboot_enabled` to `true`).
 
 #### Deploying updates
 
-`cd ansible && ansible-playbook -i inventory/production deploy-update.yml --tags update`
+`cd ansible && ansible-playbook -i inventory/production deploy-update.yml`
 
 Running the role with `reboot_enabled` will reboot a host that requires reboot
 after package upgrades:
 
-`cd ansible && ansible-playbook -i inventory/production deploy-update.yml --tags update --extra-vars=reboot_enabled=true`
+`cd ansible && ansible-playbook -i inventory/production deploy-update.yml --extra-vars=reboot_enabled=true`
 
 ### Deploy BigBlueButton
 

--- a/ansible/deploy-update.yml
+++ b/ansible/deploy-update.yml
@@ -11,5 +11,10 @@
 - name: "Update mailserver (mailcow)"
   hosts: mailserver
   become: true
-  roles:
-    - mailcow
+  tasks:
+    - name: Run mailcow's update-mailcow task
+      include_role:
+        name: mailcow
+        tasks_from: update-mailcow
+  # Ignore error on check mode
+  ignore_errors: "{{ ansible_check_mode }}"

--- a/ansible/deploy-update.yml
+++ b/ansible/deploy-update.yml
@@ -12,4 +12,4 @@
   hosts: mailserver
   become: true
   roles:
-    - { role: mailcow, tags: update }
+    - mailcow

--- a/ansible/roles/mailcow/tasks/main.yml
+++ b/ansible/roles/mailcow/tasks/main.yml
@@ -74,6 +74,8 @@
 - name: Updates mailcow
   import_tasks: update-mailcow.yml
   when: mc_check_updates and mc_conf.stat.exists
+  # Ignore error in check mode as it needs to run the update script
+  ignore_errors: "{{ ansible_check_mode }}"
   tags:
     - update
     # TODO: Make update tasks idempotent

--- a/ansible/roles/mailcow/tasks/update-mailcow.yml
+++ b/ansible/roles/mailcow/tasks/update-mailcow.yml
@@ -23,13 +23,14 @@
   command: "./update.sh --force"
   args:
     chdir: "{{ mc_install_dir }}"
-  when: check_updates.rc  == 0
+  failed_when: check_updates.rc == 1
+  register: update_script
+  until: update_script.rc != 2
   notify:
     - docker-compose up
 
 - name: Send update messages to syslog
   syslogger:
-    ident: "Mailcow Updater"
-    msg: "{{ expect_update_result.stdout }}"
+    msg: "Mailcow update: {{ update_script.stdout }}"
+    facility: "daemon"
     log_pid: true
-  when: check_updates.rc  == 0

--- a/ansible/roles/update/tasks/debian.yml
+++ b/ansible/roles/update/tasks/debian.yml
@@ -4,6 +4,8 @@
   apt:
     cache_valid_time: "{{ apt_cache_time }}"
     upgrade: safe
+  # BigBlueButton is sensitive with unattended package upgrades
+  when: inventory_hostname not in groups['bigbluebutton']|default([])
 
 - name: Install unattended-upgrades
   apt:
@@ -50,4 +52,6 @@
     path: /var/run/reboot-required
   register: reboot_required
   notify: reboot
-  when: reboot_enabled|default(false)|bool == true
+  when:
+    - reboot_enabled|default(false)|bool == true
+    - inventory_hostname not in groups['bigbluebutton']|default([])


### PR DESCRIPTION
- Fix the playbook to not apply the update tag to all tasks of the role
- Update README to add the update tag info
- Ignore errors in check mode as the role needs to first run the update
  script to get the exit codes (rc)
- Fix send update output to syslog