### PR TITLE
Do not rate limit the download speed of APT udpates

### DIFF
--- a/ansible/roles/update/defaults/main.yml
+++ b/ansible/roles/update/defaults/main.yml
@@ -32,7 +32,7 @@ unattended_minimal_steps: true
 unattended_mail: true
 
 # Use apt bandwidth limit feature, limits download speed to 200kb/sec
-unattended_dl_limit: 200
+#unattended_dl_limit: 200
 
 # Enable logging to syslog. Default is False
 unattended_syslog: true


### PR DESCRIPTION
Makes updating systems slow. Could uncomment the option if it's needed.