### PR TITLE
Attempt at solving broken install

### DIFF
--- a/ansible/roles/discourse/defaults/main.yml
+++ b/ansible/roles/discourse/defaults/main.yml
@@ -7,7 +7,7 @@ dis_guest_path: /shared
 dis_path: /var/discourse
 dis_git: https://github.com/discourse/discourse_docker.git
 # Use a stable release - https://github.com/discourse/discourse/releases
-dis_version: v3.0.2
+dis_version: v3.0.4
 # The domain name this Discourse instance will respond to.
 # Required. Discourse will not work with a bare IP number.
 dis_hostname: discourse.example.org

--- a/ansible/roles/discourse/templates/standalone.yml.j2
+++ b/ansible/roles/discourse/templates/standalone.yml.j2
@@ -99,8 +99,8 @@ hooks:
     - exec:
         cd: $home
         cmd:
-          - git fetch --depth=1 origin tag {{ dis_version }} --no-tags
-          - git checkout {{ dis_version }}
+          - sudo -H -E -u discourse git fetch --depth=1 origin tag {{ dis_version }} --no-tags
+          - sudo -H -E -u discourse git checkout {{ dis_version }}
 
 ## Any custom commands to run after building
 run:


### PR DESCRIPTION
An issue similar to [1] was breaking the deployment. The fix applies a patches to the docker template we're using. They're similar to [2].

[1]: https://meta.discourse.org/t/forum-offline-trouble-updating/257851/5
[2]: https://github.com/discourse/discourse_docker/commit/05ee40d778e4d19e631f38877cebc2af447b53c7